### PR TITLE
Fix mislabeled assist stat

### DIFF
--- a/src/lib/game/utils.ts
+++ b/src/lib/game/utils.ts
@@ -17,7 +17,7 @@ export function statLabel(t: StatType): string {
   switch (t) {
     case 'GOAL': return 'Goal';
     case 'SHOT': return 'Shot';
-    case 'ASSIST': return 'Assits';
+    case 'ASSIST': return 'Assists';
     case 'BLOCK': return 'Block';
     case 'STEAL': return 'Steal';
     case 'DRAWN_EXCLUSION': return 'Drawn Exclusion';


### PR DESCRIPTION
## Summary
- fix the "Assists" label returned by `statLabel`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68881b3a7fe883249905e7ccafde42b8