### PR TITLE
Add pre-defined team option for new games

### DIFF
--- a/src/lib/predefinedTeams.ts
+++ b/src/lib/predefinedTeams.ts
@@ -1,0 +1,23 @@
+import { v4 as uuid } from 'uuid';
+import type { Player } from './types';
+
+export interface TeamTemplate {
+  id: string;
+  name: string;
+  players: { number: number; name: string }[];
+}
+
+export const PREDEFINED_TEAMS: TeamTemplate[] = [
+  {
+    id: 'sample',
+    name: 'Sample Team',
+    players: Array.from({ length: 13 }).map((_, i) => ({
+      number: i + 1,
+      name: `Player ${i + 1}`
+    }))
+  }
+];
+
+export function cloneTemplatePlayers(template: TeamTemplate): Player[] {
+  return template.players.map((p) => ({ id: uuid(), number: p.number, name: p.name }));
+}

--- a/src/routes/game/new/+page.svelte
+++ b/src/routes/game/new/+page.svelte
@@ -3,6 +3,7 @@
   import { goto } from '$app/navigation';
   import { v4 as uuid } from 'uuid';
   import type { Player } from '$lib/types';
+  import { PREDEFINED_TEAMS, cloneTemplatePlayers } from '$lib/predefinedTeams';
 
   let opponentName = '';
   let date = new Date().toISOString().slice(0, 10);
@@ -10,12 +11,21 @@
   let periods = 4;
   let autoShotOnGoal = true;
 
+  let selectedTemplate = '';
+
   // start w/ 13 empty roster slots
   let players: Player[] = Array.from({ length: 13 }).map((_, i) => ({
     id: uuid(),
     number: i + 1,
     name: ''
   }));
+
+  function applyTemplate(id: string) {
+    const t = PREDEFINED_TEAMS.find((tt) => tt.id === id);
+    if (!t) return;
+    homeTeamName = t.name;
+    players = cloneTemplatePlayers(t);
+  }
 
   async function create() {
     const activePlayers = players.filter((p) => p.name.trim() !== '');
@@ -35,6 +45,15 @@
   <h1 class="text-2xl font-bold">New Game</h1>
 
   <div class="grid gap-4">
+    <label class="grid gap-1">
+      <span class="text-sm font-medium">Use Predefined Team</span>
+      <select class="input" bind:value={selectedTemplate} onchange={() => applyTemplate(selectedTemplate)}>
+        <option value="">-- None --</option>
+        {#each PREDEFINED_TEAMS as t}
+          <option value={t.id}>{t.name}</option>
+        {/each}
+      </select>
+    </label>
     <label class="grid gap-1">
       <span class="text-sm font-medium">Opponent Name</span>
       <input bind:value={opponentName} class="input" placeholder="Opponent" />
@@ -70,7 +89,7 @@
 
   <button
     type="button"
-    on:click={create}
+    onclick={create}
     class="w-full py-4 rounded-lg bg-green-600 text-white text-xl font-bold"
   >
     Create Game


### PR DESCRIPTION
## Summary
- add `predefinedTeams.ts` with a simple sample team
- extend the New Game page to optionally load a team template
- fix event handler syntax to use `onchange`/`onclick`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68881db6a7d08324a659b5c840b1ca88