### PR TITLE
Implement team selection autocomplete

### DIFF
--- a/src/lib/components/TeamAutocomplete.svelte
+++ b/src/lib/components/TeamAutocomplete.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { teamStore } from '$lib/stores/teamStore';
+  import { onDestroy } from 'svelte';
+  import type { TeamIndexEntry } from '$lib/stores/teamStore';
+  import type { ID } from '$lib/types';
+
+  // Bindable props
+  let {
+    selectedTeamId = $bindable(''),
+    teamName = $bindable('')
+  } = $props<{ selectedTeamId?: ID | ''; teamName?: string }>();
+
+  let teams: TeamIndexEntry[] = $state([]);
+  const unsub = teamStore.teams.subscribe((v) => (teams = v));
+  onDestroy(() => unsub());
+
+  // Keep teamName in sync if selectedTeamId changes externally
+  $effect(() => {
+    if (selectedTeamId) {
+      const t = teams.find((tt) => tt.id === selectedTeamId);
+      if (t && teamName !== t.name) teamName = t.name;
+    }
+  });
+
+  function onInput(e: Event) {
+    const value = (e.target as HTMLInputElement).value;
+    teamName = value;
+    const match = teams.find((t) => t.name === value);
+    selectedTeamId = match?.id ?? '';
+  }
+</script>
+
+<div class="relative">
+  <input
+    list="team-names"
+    class="input"
+    bind:value={teamName}
+    oninput={onInput}
+    placeholder="Our Team"
+  />
+  <datalist id="team-names">
+    {#each teams as t}
+      <option value={t.name}></option>
+    {/each}
+  </datalist>
+</div>

--- a/src/routes/game/new/+page.svelte
+++ b/src/routes/game/new/+page.svelte
@@ -3,6 +3,7 @@
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
   import { teamStore } from '$lib/stores/teamStore';
+  import TeamAutocomplete from '$lib/components/TeamAutocomplete.svelte';
   import { v4 as uuid } from 'uuid';
   import type { Player, ID } from '$lib/types';
   import type { TeamIndexEntry } from '$lib/stores/teamStore';
@@ -103,25 +104,10 @@
       <input type="date" bind:value={date} class="input" />
     </label>
 
-    {#if teams.length > 0}
-      <label class="grid gap-1">
-        <span class="text-sm font-medium">Team</span>
-        <select class="input" bind:value={selectedTeamId}>
-          <option value="">Custom roster…</option>
-          {#each teams as t}
-            <option value={t.id}>{t.name}</option>
-          {/each}
-        </select>
-        {#if !selectedTeamId}
-          <input class="input mt-2" bind:value={homeTeamName} placeholder="Our Team" />
-        {/if}
-      </label>
-    {:else}
-      <label class="grid gap-1">
-        <span class="text-sm font-medium">Team Name</span>
-        <input bind:value={homeTeamName} class="input" />
-      </label>
-    {/if}
+    <label class="grid gap-1">
+      <span class="text-sm font-medium">Team</span>
+      <TeamAutocomplete bind:selectedTeamId bind:teamName={homeTeamName} />
+    </label>
 
     <label class="inline-flex items-center gap-2">
       <input type="checkbox" bind:checked={autoShotOnGoal} />


### PR DESCRIPTION
## Summary
- add a `TeamAutocomplete` component with datalist suggestions
- use the new component in the new game page

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_688947ca40888324818b51e982bfd7f9