### PR TITLE
Fix home team field defaults

### DIFF
--- a/src/routes/game/new/+page.svelte
+++ b/src/routes/game/new/+page.svelte
@@ -10,7 +10,7 @@
 
   let opponentName = $state('');
   let date = $state(new Date().toISOString().slice(0, 10));
-  let homeTeamName = $state('Our Team');
+  let homeTeamName = $state('');
   let periods = 4;
   let autoShotOnGoal = $state(true);
 
@@ -44,7 +44,7 @@
   // Load roster when a team is selected or reset when using a custom roster
   $effect(() => {
     if (!selectedTeamId) {
-      homeTeamName = 'Our Team';
+      homeTeamName = '';
       players = defaultPlayers();
       return;
     }


### PR DESCRIPTION
## Summary
- leave the home team field empty when creating a new game

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6889566590b88324944b9d042c097aef