### PR TITLE
Enlarge edit icon and center align

### DIFF
--- a/src/routes/game/new/+page.svelte
+++ b/src/routes/game/new/+page.svelte
@@ -112,11 +112,11 @@
         }}
       />
     {:else}
-      <span class="text-sm text-slate-700">
-        {date}
+      <span class="inline-flex items-center text-sm text-slate-700">
+        <span>{date}</span>
         <button
           type="button"
-          class="ml-2 p-1 rounded-full text-blue-600 hover:text-blue-700 hover:bg-blue-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+          class="ml-2 inline-flex items-center justify-center p-2 rounded-full text-blue-600 hover:text-blue-700 hover:bg-blue-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
           aria-label="Edit date"
           title="Edit date"
           onclick={() => {
@@ -125,7 +125,7 @@
           }}
         >
           <!-- Pencil icon -->
-          <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <svg class="w-6 h-6" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z"></path>
             <path d="M20.71 7.04a1 1 0 0 0 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"></path>
           </svg>


### PR DESCRIPTION
## Summary
- style the date editing button
- align pencil icon with date label

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_688a7b9171f48324ba78eb14bccb3cdb