### PR TITLE
Unify responsive layout with Tailwind

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -3,6 +3,7 @@
 
 @layer components {
   .input {@apply px-3 py-2 rounded border border-slate-300 bg-white text-lg w-full;}
+  .page-container {@apply mx-auto w-full max-w-3xl;}
 }
 
 html, body {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -94,7 +94,7 @@
 </script>
 
 <!-- Toolbar: only New‑Game button -------------------------------->
-<div class="max-w-xl mx-auto flex justify-end mb-6">
+<div class="page-container flex justify-end mb-6">
   <button
     type="button"
     class="inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
@@ -105,7 +105,7 @@
 </div>
 
 <!-- Main content -------------------------------------------------->
-<div class="max-w-xl mx-auto space-y-6">
+<div class="page-container space-y-6">
   {#if sortedGames.length === 0}
     <p class="p-4 text-center text-slate-500">No games yet.</p>
   {:else}

--- a/src/routes/game/[id]/+page.svelte
+++ b/src/routes/game/[id]/+page.svelte
@@ -190,7 +190,7 @@
 
 {#if game}
   {@const g = game!}
-  <div class="space-y-6 max-w-5xl mx-auto">
+  <div class="space-y-6 page-container">
 
     <!-- Score & Period Controls -->
     <div class="space-y-1">

--- a/src/routes/game/[id]/export/+page.svelte
+++ b/src/routes/game/[id]/export/+page.svelte
@@ -71,7 +71,7 @@
 
 <style lang="postcss">
   /* Make Tailwind utilities visible in this scoped style block */
-  @reference "../../app.css";
+  @reference "../../../../app.css";
 
   /* Shared input style (scoped to this component) */
   .input {

--- a/src/routes/game/new/+page.svelte
+++ b/src/routes/game/new/+page.svelte
@@ -92,7 +92,7 @@
   }
 </script>
 
-<div class="space-y-6 max-w-2xl mx-auto">
+<div class="space-y-6 page-container">
   <div class="flex items-center justify-between">
     <h1 class="text-2xl font-bold">New Game</h1>
     {#if editingDate}

--- a/src/routes/teams/+page.svelte
+++ b/src/routes/teams/+page.svelte
@@ -37,7 +37,7 @@
 </script>
 
 <!-- Page header -->
-<div class="max-w-4xl mx-auto mb-6 flex items-center justify-between">
+<div class="page-container mb-6 flex items-center justify-between">
   <h1 class="text-2xl font-bold">Teams</h1>
   <button
     type="button"
@@ -49,7 +49,7 @@
 </div>
 
 <!-- Teams list -->
-<div class="max-w-4xl mx-auto">
+<div class="page-container">
   <div class="rounded-2xl bg-white shadow ring-1 ring-gray-200 p-4">
     {#if sortedTeams.length === 0}
       <p class="text-sm text-slate-500">No teams yet.</p>

--- a/src/routes/teams/[id]/+page.svelte
+++ b/src/routes/teams/[id]/+page.svelte
@@ -79,7 +79,7 @@
   }
 </script>
 
-<div class="mx-auto w-full max-w-3xl px-4 sm:px-6 lg:px-8 py-4 sm:py-6">
+<div class="page-container px-4 sm:px-6 lg:px-8 py-4 sm:py-6">
   <!-- Page heading -->
   <div class="mb-4 sm:mb-6">
     <h1 class="text-2xl sm:text-3xl font-bold tracking-tight text-slate-900">Edit Team</h1>

--- a/src/routes/teams/new/+page.svelte
+++ b/src/routes/teams/new/+page.svelte
@@ -38,7 +38,7 @@
   });
 </script>
 
-<div class="mx-auto w-full max-w-3xl px-4 sm:px-6 lg:px-8 py-4 sm:py-6">
+<div class="page-container px-4 sm:px-6 lg:px-8 py-4 sm:py-6">
   <!-- Page heading -->
   <div class="mb-4 sm:mb-6">
     <h1 class="text-2xl sm:text-3xl font-bold tracking-tight text-slate-900">Create Team</h1>


### PR DESCRIPTION
## Summary
- add `.page-container` Tailwind class for consistent width
- update all pages to use the new container class
- fix wrong Tailwind reference path in export page

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b9a88fff883248e8f69630654e739