### PR TITLE
feat: add icons for home and visitor

### DIFF
--- a/src/lib/components/Scoreboard.svelte
+++ b/src/lib/components/Scoreboard.svelte
@@ -13,7 +13,13 @@
 </script>
 
 <div class="grid grid-cols-3 items-center gap-2 text-center">
-  <div class="truncate text-xl font-semibold">{homeName}</div>
+  <div class="truncate text-xl font-semibold flex items-center justify-center gap-1">
+    <span aria-hidden="true">🏠</span>
+    {homeName}
+  </div>
   <div class="text-3xl font-bold">{score.home} : {score.opponent}</div>
-  <div class="truncate text-xl font-semibold">{opponentName}</div>
+  <div class="truncate text-xl font-semibold flex items-center justify-center gap-1">
+    <span aria-hidden="true">✈️</span>
+    {opponentName}
+  </div>
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -166,10 +166,10 @@
             {/if}
 
             <!-- Names & date -->
-            <div class="text-lg font-semibold leading-tight">
-              {details[g.id]?.name ?? 'Our Team'}
+            <div class="text-lg font-semibold leading-tight flex items-center gap-1">
+              <span aria-hidden="true">🏠</span>{details[g.id]?.name ?? 'Our Team'}
               <span class="mx-1 text-slate-400">vs</span>
-              {g.opponentName ?? 'Opponent'}
+              <span aria-hidden="true">✈️</span>{g.opponentName ?? 'Opponent'}
             </div>
             <div class="text-sm text-slate-500 mt-1">{g.date}</div>
           </div>


### PR DESCRIPTION
## Summary
- show a home icon next to the home team on the scoreboard
- show a visitor icon next to the opponent team on the scoreboard and game list

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689646bdae088324b2f89c2f4c60b196