### PR TITLE
Revert addition of home/visitor icons

### DIFF
--- a/src/lib/components/Scoreboard.svelte
+++ b/src/lib/components/Scoreboard.svelte
@@ -13,13 +13,7 @@
 </script>
 
 <div class="grid grid-cols-3 items-center gap-2 text-center">
-  <div class="truncate text-xl font-semibold flex items-center justify-center gap-1">
-    <span aria-hidden="true">🏠</span>
-    {homeName}
-  </div>
+  <div class="truncate text-xl font-semibold">{homeName}</div>
   <div class="text-3xl font-bold">{score.home} : {score.opponent}</div>
-  <div class="truncate text-xl font-semibold flex items-center justify-center gap-1">
-    <span aria-hidden="true">✈️</span>
-    {opponentName}
-  </div>
+  <div class="truncate text-xl font-semibold">{opponentName}</div>
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -166,10 +166,10 @@
             {/if}
 
             <!-- Names & date -->
-            <div class="text-lg font-semibold leading-tight flex items-center gap-1">
-              <span aria-hidden="true">🏠</span>{details[g.id]?.name ?? 'Our Team'}
+            <div class="text-lg font-semibold leading-tight">
+              {details[g.id]?.name ?? 'Our Team'}
               <span class="mx-1 text-slate-400">vs</span>
-              <span aria-hidden="true">✈️</span>{g.opponentName ?? 'Opponent'}
+              {g.opponentName ?? 'Opponent'}
             </div>
             <div class="text-sm text-slate-500 mt-1">{g.date}</div>
           </div>


### PR DESCRIPTION
## Summary
- Revert merge that added emoji icons beside team names
- Restore plain text display for home and opponent names

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689648313d2c83248769b15801c80199