### PR TITLE
chore: change default dev port

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ npm run dev
 npm run dev -- --open
 ```
 
+The development server listens on [http://localhost:5174](http://localhost:5174) by default.
+
 ## Building
 
 To create a production version of your app:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,11 @@ import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
-  plugins: [tailwindcss(), sveltekit()]
+  plugins: [tailwindcss(), sveltekit()],
+  server: {
+    port: 5174
+  },
+  preview: {
+    port: 5174
+  }
 });


### PR DESCRIPTION
## Summary
- run dev server on port 5174 to avoid conflicts
- document new default server port

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68966573ea348324b4f33ec4691692d1